### PR TITLE
TLC-136: Files voiding metadata excluded from config validation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -428,7 +428,10 @@
             <configuration>
               <target>
                 <copy todir="${project.build.directory}/configuration">
-                  <fileset dir="${distro.openmrsconfigDir}"/>
+                  <!-- Exclude files with names containing "*void*" -->
+                  <fileset dir="${distro.openmrsconfigDir}">
+                      <exclude name="**/*void*"/>
+                  </fileset>
                 </copy>
               </target>
             </configuration>


### PR DESCRIPTION
Ticket: https://mekomsolutions.atlassian.net/browse/TLC-136